### PR TITLE
[리팩토링] 통계 API 개선 

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -37,10 +37,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
 
-    implementation 'org.springframework.cloud:spring-cloud-starter-config'
-    implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.retry:spring-retry'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'io.github.openfeign:feign-jackson:11.9'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:4.44.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.44.0'
 }
 
 dependencyManagement {

--- a/api/src/main/java/com/core/api/ApiApplication.java
+++ b/api/src/main/java/com/core/api/ApiApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableFeignClients
 @EnableJpaAuditing
+@EnableScheduling
 public class ApiApplication {
 
     public static void main(String[] args) {

--- a/api/src/main/java/com/core/api/config/BackendFeignConfig.java
+++ b/api/src/main/java/com/core/api/config/BackendFeignConfig.java
@@ -14,7 +14,6 @@ public class BackendFeignConfig {
             System.out.println(requestTemplate.url());
             if (!requestTemplate.url()
                     .equals("/users/search/git-token")) {
-                System.out.println("testestestsetset");
                 String token = getAccessToken();
                 requestTemplate.header("Authorization", token);
             }

--- a/api/src/main/java/com/core/api/config/ShedLockConfig.java
+++ b/api/src/main/java/com/core/api/config/ShedLockConfig.java
@@ -1,0 +1,25 @@
+package com.core.api.config;
+
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableSchedulerLock(defaultLockAtLeastFor = "30s", defaultLockAtMostFor = "30s")
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource){
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(new JdbcTemplate(dataSource))
+                        .build()
+        );
+    }
+}

--- a/api/src/main/java/com/core/api/data/entity/RepoInfo.java
+++ b/api/src/main/java/com/core/api/data/entity/RepoInfo.java
@@ -1,0 +1,21 @@
+package com.core.api.data.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class RepoInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "repo_name")
+    private String name;
+
+    @Column(name = "repo_owner")
+    private String owner;
+
+}

--- a/api/src/main/java/com/core/api/data/entity/Stats.java
+++ b/api/src/main/java/com/core/api/data/entity/Stats.java
@@ -1,0 +1,72 @@
+package com.core.api.data.entity;
+
+import com.core.api.data.dto.StatsDto;
+import com.core.api.data.dto.github.PullRequestServerDto;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+public class Stats {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String owner;
+    private String repo;
+
+    private int totalCommit;
+    private int currentWeekCommit;
+    private int lastWeekCommit;
+    private double commitGrowthRate;
+
+    private int totalPullRequest;
+    private int currentWeekPullRequest;
+    private int lastWeekPullRequest;
+    private double pullRequestGrowthRate;
+
+    private int totalReview;
+    private int currentWeekReview;
+    private int lastWeekReview;
+    private double reviewGrowthRate;
+
+    private int totalHotfix;
+    private int currentWeekHotfix;
+    private int lastWeekHotfix;
+    private double hotfixGrowthRate;
+
+    public static Stats createStats(StatsDto dto) {
+        Stats stats = new Stats();
+
+        stats.totalCommit = dto.getTotalCommit();
+        stats.currentWeekCommit = dto.getCurrentWeekCommit();
+        stats.lastWeekCommit = dto.getLastWeekCommit();
+        stats.commitGrowthRate = dto.getCommitGrowthRate();
+
+        stats.totalPullRequest = dto.getTotalPullRequest();
+        stats.currentWeekPullRequest = dto.getCurrentWeekPullRequest();
+        stats.lastWeekPullRequest = dto.getLastWeekPullRequest();
+        stats.pullRequestGrowthRate = dto.getPullRequestGrowthRate();
+
+        stats.totalReview = dto.getTotalReview();
+        stats.currentWeekReview = dto.getCurrentWeekReview();
+        stats.lastWeekReview = dto.getLastWeekReview();
+        stats.reviewGrowthRate = dto.getReviewGrowthRate();
+
+        stats.totalHotfix = dto.getTotalHotfix();
+        stats.currentWeekHotfix = dto.getCurrentWeekHotfix();
+        stats.lastWeekHotfix = dto.getLastWeekHotfix();
+        stats.hotfixGrowthRate = dto.getHotfixGrowthRate();
+
+        return stats;
+    }
+
+
+}

--- a/api/src/main/java/com/core/api/data/repository/RepoInfoRepository.java
+++ b/api/src/main/java/com/core/api/data/repository/RepoInfoRepository.java
@@ -1,0 +1,7 @@
+package com.core.api.data.repository;
+
+import com.core.api.data.entity.RepoInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RepoInfoRepository extends JpaRepository<RepoInfo,Long> {
+}

--- a/api/src/main/java/com/core/api/data/repository/StatsRepository.java
+++ b/api/src/main/java/com/core/api/data/repository/StatsRepository.java
@@ -1,0 +1,7 @@
+package com.core.api.data.repository;
+
+import com.core.api.data.entity.Stats;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StatsRepository extends JpaRepository<Stats,Long> {
+}

--- a/api/src/main/java/com/core/api/filter/LoggingFilter.java
+++ b/api/src/main/java/com/core/api/filter/LoggingFilter.java
@@ -5,8 +5,10 @@ import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Component
@@ -16,11 +18,19 @@ public class LoggingFilter implements Filter {
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
         if(servletRequest instanceof HttpServletRequest httpServletRequest){
-            String url = httpServletRequest.getRequestURI();
-            String method = httpServletRequest.getMethod();
-            log.trace("들어오는 요청 : URL={}, Method={}",url,method);
+
+            ContentCachingRequestWrapper cachingRequest = new ContentCachingRequestWrapper(httpServletRequest);
+
+            String url = cachingRequest.getRequestURI();
+            String method = cachingRequest.getMethod();
+            String body = cachingRequest.getReader().lines().reduce("",String::concat);
+
+            log.trace("들어오는 요청 : URL={}, Method={} Body={}",url,method,body);
+            filterChain.doFilter(cachingRequest,servletResponse);
+            return;
         }
 
-        filterChain.doFilter(servletRequest,servletResponse);
+       filterChain.doFilter(servletRequest,servletResponse);
     }
+
 }

--- a/api/src/main/java/com/core/api/scheduler/StatsScheduledTask.java
+++ b/api/src/main/java/com/core/api/scheduler/StatsScheduledTask.java
@@ -80,12 +80,12 @@ public class StatsScheduledTask {
         double reviewGrowthRate = calculateGrowthRate(currentWeekReview, lastWeekReview);
 
         int currentWeekHotfix = countItemsWithinPeriod(
-                pullRequests.stream()
+                pullRequests.parallelStream()
                         .filter(PullRequest::getAfterReview)
                         .toList(),
                 PullRequest::getDeadline, startOfThisWeek, startOfThisWeek.plusWeeks(1));
         int lastWeekHotfix = countItemsWithinPeriod(
-                pullRequests.stream()
+                pullRequests.parallelStream()
                         .filter(PullRequest::getAfterReview)
                         .toList(),
                 PullRequest::getDeadline, startOfLastWeek, startOfThisWeek);
@@ -123,13 +123,13 @@ public class StatsScheduledTask {
     }
 
     private <T> int countItemsWithinPeriod(List<T> items, Function<T, LocalDateTime> dateExtractor, LocalDateTime start, LocalDateTime end) {
-        return (int) items.stream()
+        return (int) items.parallelStream()
                 .filter(item -> isWithinPeriod(dateExtractor.apply(item), start, end))
                 .count();
     }
 
     private int countCommitsWithinPeriod(List<PullRequest> pullRequests, LocalDateTime start, LocalDateTime end) {
-        return pullRequests.stream()
+        return pullRequests.parallelStream()
                 .flatMap(pr -> pr.getCommits()
                         .stream())
                 .filter(commit -> isWithinPeriod(commit.getCreatedDate(), start, end))
@@ -138,11 +138,11 @@ public class StatsScheduledTask {
     }
 
     private int countReviewsWithinPeriod(List<PullRequest> pullRequests, LocalDateTime start, LocalDateTime end) {
-        return pullRequests.stream()
+        return pullRequests.parallelStream()
                 .flatMap(pr -> pr.getReviewers()
-                        .stream())
+                        .parallelStream())
                 .flatMap(reviewer -> reviewer.getReviews()
-                        .stream())
+                        .parallelStream())
                 .filter(review -> isWithinPeriod(review.getCreatedDate(), start, end))
                 .toList()
                 .size();

--- a/api/src/main/java/com/core/api/scheduler/StatsScheduledTask.java
+++ b/api/src/main/java/com/core/api/scheduler/StatsScheduledTask.java
@@ -1,0 +1,163 @@
+package com.core.api.scheduler;
+
+import com.core.api.data.dto.DayDto;
+import com.core.api.data.dto.StatsDto;
+import com.core.api.data.entity.PullRequest;
+import com.core.api.data.entity.RepoInfo;
+import com.core.api.data.entity.Stats;
+import com.core.api.data.repository.PullRequestRepository;
+import com.core.api.data.repository.RepoInfoRepository;
+import com.core.api.data.repository.StatsRepository;
+import com.core.api.data.repository.VersionRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.WeekFields;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+@Component
+@RequiredArgsConstructor
+public class StatsScheduledTask {
+
+
+    private final PullRequestRepository pullRequestRepository;
+    private final StatsRepository statsRepository;
+    private final RepoInfoRepository repoInfoRepository;
+
+
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    @SchedulerLock(name = "scheduler_stats_task")
+    public void dailyStatsForAllRepositories() {
+        List<RepoInfo> repositories = repoInfoRepository.findAll();
+
+        for (RepoInfo repository : repositories) {
+            dailyStats(repository.getOwner(), repository.getName());
+        }
+    }
+
+    public void  dailyStats(String owner, String repo) {
+        List<PullRequest> pullRequests = pullRequestRepository.findAllByOwnerAndRepo(owner, repo)
+                .orElse(List.of());
+
+        int totalPullRequest = pullRequests.size();
+
+        LocalDateTime startOfThisWeek = getStartOfThisWeek();
+        LocalDateTime startOfLastWeek = startOfThisWeek.minusWeeks(1);
+
+        int currentWeekPullRequest = countItemsWithinPeriod(pullRequests, PullRequest::getDeadline, startOfThisWeek, startOfThisWeek.plusWeeks(1));
+        int lastWeekPullRequest = countItemsWithinPeriod(pullRequests, PullRequest::getDeadline, startOfLastWeek, startOfThisWeek);
+        double pullRequestGrowthRate = calculateGrowthRate(currentWeekPullRequest, lastWeekPullRequest);
+
+        int totalCommit = pullRequests.stream()
+                .mapToInt(pr -> pr.getCommits()
+                        .size())
+                .sum();
+        int totalReview = pullRequests.stream()
+                .flatMap(pr -> pr.getReviewers()
+                        .stream())
+                .mapToInt(reviewer -> reviewer.getReviews()
+                        .size())
+                .sum();
+        int totalHotfix = (int) pullRequests.stream()
+                .filter(PullRequest::getAfterReview)
+                .count();
+
+        int currentWeekCommit = countCommitsWithinPeriod(pullRequests, startOfThisWeek, startOfThisWeek.plusWeeks(1));
+        int lastWeekCommit = countCommitsWithinPeriod(pullRequests, startOfLastWeek, startOfThisWeek);
+        double commitGrowthRate = calculateGrowthRate(currentWeekCommit, lastWeekCommit);
+
+        int currentWeekReview = countReviewsWithinPeriod(pullRequests, startOfThisWeek, startOfThisWeek.plusWeeks(1));
+        int lastWeekReview = countReviewsWithinPeriod(pullRequests, startOfLastWeek, startOfThisWeek);
+        double reviewGrowthRate = calculateGrowthRate(currentWeekReview, lastWeekReview);
+
+        int currentWeekHotfix = countItemsWithinPeriod(
+                pullRequests.stream()
+                        .filter(PullRequest::getAfterReview)
+                        .toList(),
+                PullRequest::getDeadline, startOfThisWeek, startOfThisWeek.plusWeeks(1));
+        int lastWeekHotfix = countItemsWithinPeriod(
+                pullRequests.stream()
+                        .filter(PullRequest::getAfterReview)
+                        .toList(),
+                PullRequest::getDeadline, startOfLastWeek, startOfThisWeek);
+        double hotfixGrowthRate = calculateGrowthRate(currentWeekHotfix, lastWeekHotfix);
+
+        Stats newStats = Stats.createStats(
+                StatsDto.builder()
+                .totalCommit(totalCommit)
+                .currentWeekCommit(currentWeekCommit)
+                .lastWeekCommit(lastWeekCommit)
+                .commitGrowthRate(commitGrowthRate)
+                .totalPullRequest(totalPullRequest)
+                .currentWeekPullRequest(currentWeekPullRequest)
+                .lastWeekPullRequest(lastWeekPullRequest)
+                .pullRequestGrowthRate(pullRequestGrowthRate)
+                .totalReview(totalReview)
+                .currentWeekReview(currentWeekReview)
+                .lastWeekReview(lastWeekReview)
+                .reviewGrowthRate(reviewGrowthRate)
+                .totalHotfix(totalHotfix)
+                .currentWeekHotfix(currentWeekHotfix)
+                .lastWeekHotfix(lastWeekHotfix)
+                .hotfixGrowthRate(hotfixGrowthRate)
+                .build());
+        statsRepository.save(newStats);
+    }
+
+
+    private LocalDateTime getStartOfThisWeek() {
+        return LocalDateTime.now()
+                .with(TemporalAdjusters.previousOrSame(WeekFields.of(Locale.getDefault())
+                        .getFirstDayOfWeek()))
+                .toLocalDate()
+                .atStartOfDay();
+    }
+
+    private <T> int countItemsWithinPeriod(List<T> items, Function<T, LocalDateTime> dateExtractor, LocalDateTime start, LocalDateTime end) {
+        return (int) items.stream()
+                .filter(item -> isWithinPeriod(dateExtractor.apply(item), start, end))
+                .count();
+    }
+
+    private int countCommitsWithinPeriod(List<PullRequest> pullRequests, LocalDateTime start, LocalDateTime end) {
+        return pullRequests.stream()
+                .flatMap(pr -> pr.getCommits()
+                        .stream())
+                .filter(commit -> isWithinPeriod(commit.getCreatedDate(), start, end))
+                .toList()
+                .size();
+    }
+
+    private int countReviewsWithinPeriod(List<PullRequest> pullRequests, LocalDateTime start, LocalDateTime end) {
+        return pullRequests.stream()
+                .flatMap(pr -> pr.getReviewers()
+                        .stream())
+                .flatMap(reviewer -> reviewer.getReviews()
+                        .stream())
+                .filter(review -> isWithinPeriod(review.getCreatedDate(), start, end))
+                .toList()
+                .size();
+    }
+
+    private boolean isWithinPeriod(LocalDateTime date, LocalDateTime start, LocalDateTime end) {
+        return date != null && (date.isEqual(start) || date.isAfter(start)) && date.isBefore(end);
+    }
+
+    private double calculateGrowthRate(int current, int last) {
+        if (last == 0) return current > 0 ? 100.0 : 0;
+        return ((double) (current - last) / last) * 100;
+    }
+
+
+
+
+}


### PR DESCRIPTION
### 문제점 
현재 통계 API 호출 시 모든 리포지토리를 돌면서 계산 후 반환한다.  메인 페이지에 들어올 때마다 호출하기 때문에 매번 계산하는게 비효율적이다. 

### 해결 방법
1. 통계테이블을 만들어  따로 저장한다. -> Stats 엔티티 생성
2. 스케줄링을 적용해 정각마다 통계를 계산해 저장한다. 

### 고민한 점 
1. Spring Batch  vs @Scheduled
- 간단하고 단일 서버에서 빠르게 처리 가능한 작업이면 @Scheduled가 적합하다.
- 복잡한 작업 흐름 관리, 오류 처리, 재시도 로직, 다량의 데이터 처리가 필요하다면 Spring Batch가 더 적합하다.
- 지금처럼 간단한 통계 집계라면 @Scheduled가 더 가볍고 적절하다 생각해 @Scheduled 를 사용했다.

2. 스케줄링이 중복 실행된다면?
- ShedLock 또는 Redis 기반 분산 락을 사용해 중복 실행을 방지할 수 있다.
- 현재 프로젝트에서는 Redis를 별도로 사용하고 있지 않으므로, Spring Boot에서 바로 적용 가능한 ShedLock을 선택했다.

3. 스케줄링이 중단되거나 실패한다면? 
- 에러 로그를 찍고 슬랙에 알림이 가도록 한다. (추후 추가)
- 실패시 자동으로 재시도 하도록 추가하였다.

5. 성능을 개선할 수 있을까? 
- parallelStream()을 사용해 병렬 실행하여 성능을 개선하였다.
- 개선 전 후 로그를 찍어봤을 때 14755 ms -> 1011ms 개선할 수 있었다.




```
//더미데이터 from GPT

-- 1. RepoInfo 더미 데이터 생성 (5개 레포지토리)
INSERT INTO repo_info (repo_name, repo_owner) VALUES
('repo-A', 'owner-A'),
('repo-B', 'owner-B'),
('repo-C', 'owner-C'),
('repo-D', 'owner-D'),
('repo-E', 'owner-E');

-- 2. PullRequest 더미 데이터 생성 (10,000건)
INSERT INTO pr (pr_title, pr_github_id, pr_owner, pr_repo, pr_writer_id, pr_summary, pr_head, pr_base,
                pr_description, pr_merge_status, pr_status, pr_priority, pr_after_review, pr_deadline, created_date, modified_date)
SELECT 
    CONCAT('PR Title ', id),
    1000 + id,
    CASE WHEN id % 5 = 0 THEN 'owner-A' 
         WHEN id % 5 = 1 THEN 'owner-B' 
         WHEN id % 5 = 2 THEN 'owner-C' 
         WHEN id % 5 = 3 THEN 'owner-D' 
         ELSE 'owner-E' END,
    CASE WHEN id % 5 = 0 THEN 'repo-A' 
         WHEN id % 5 = 1 THEN 'repo-B' 
         WHEN id % 5 = 2 THEN 'repo-C' 
         WHEN id % 5 = 3 THEN 'repo-D' 
         ELSE 'repo-E' END,
    CONCAT('devUser', id % 100),
    'Summary of PR',
    'feature-branch',
    'main',
    'Detailed description of PR',
    FALSE,
    'processing',
    CASE WHEN id % 3 = 0 THEN 'HIGH' ELSE 'MEDIUM' END,
    FALSE,
    DATE_ADD(NOW(), INTERVAL - FLOOR(RAND() * 365) DAY), -- 1년 이내 랜덤 마감일
    NOW(),
    NOW()
FROM (SELECT @row := @row + 1 AS id FROM 
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t1,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t2,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t3,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t4,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t5,
     (SELECT @row := 0) r) t LIMIT 10000;

-- 3. Commit 더미 데이터 생성 (75,000건, PR당 5~10개)
INSERT INTO commit (commit_sha, commit_message, commit_writer_id, commit_writer_img, pr_id, commit_parent, commit_second_parent, created_date)
SELECT 
    CONCAT('sha-', UUID()), 
    'Auto-generated commit message',
    CONCAT('devUser', id % 500),
    CONCAT('https://img.com/dev', id % 500, '.png'),
    (SELECT pr_id FROM pr ORDER BY RAND() LIMIT 1), -- ✅ 존재하는 PR ID만 선택
    NULL,
    NULL,
    DATE_ADD(NOW(), INTERVAL - FLOOR(RAND() * 90) DAY) -- 최근 3개월 내 랜덤 생성일
FROM (SELECT @row := @row + 1 AS id FROM 
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t1,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t2,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t3,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t4,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t5,
     (SELECT @row := 0) r) t LIMIT 75000;

-- 4. Reviewer 더미 데이터 생성 (30,000건, PR당 2~5명)
INSERT INTO reviewer (reviewer_user_id, reviewer_score, reviewer_content, reviewer_status, pr_id, created_date, modified_date)
SELECT 
    CONCAT('reviewer', id % 1000),
    FLOOR(RAND() * 10),
    'Review feedback content',
    TRUE,
    (SELECT pr_id FROM pr ORDER BY RAND() LIMIT 1), -- ✅ 존재하는 PR ID만 선택
    NOW(),
    NOW()
FROM (SELECT @row := @row + 1 AS id FROM 
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t1,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t2,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t3,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t4,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t5,
     (SELECT @row := 0) r) t LIMIT 30000;

-- 5. Review 더미 데이터 생성 (60,000건, Reviewer당 2~5개)
INSERT INTO review (review_pull_request_id, review_parent_id, review_line, review_path, review_content, reviewer_id, created_date, modified_date)
SELECT 
    (SELECT pr_id FROM pr ORDER BY RAND() LIMIT 1), -- ✅ 존재하는 PR ID만 선택
    NULL,
    FLOOR(RAND() * 1000),
    '/src/main/java/TestFile.java',
    'Generated review content',
    (SELECT reviewer_id FROM reviewer ORDER BY RAND() LIMIT 1), -- ✅ 존재하는 Reviewer ID만 선택
    NOW(),
    NOW()
FROM (SELECT @row := @row + 1 AS id FROM 
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t1,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t2,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t3,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t4,
     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t5,
     (SELECT @row := 0) r) t LIMIT 60000;

```
closed #2 