### PR TITLE
[리팩토링] 로그 고도화 

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 
     implementation 'net.javacrumbs.shedlock:shedlock-spring:4.44.0'
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.44.0'
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 }
 
 dependencyManagement {

--- a/api/log.conf
+++ b/api/log.conf
@@ -1,0 +1,13 @@
+input {
+    tcp {
+        port => 5044
+        codec => json
+    }
+}
+
+output {
+    elasticsearch {
+        hosts => ["http://elasticsearch:9200"]
+        index => "application-logs-%{+YYYY.MM.dd}"
+    }
+}

--- a/api/src/main/resources/logback.xml
+++ b/api/src/main/resources/logback.xml
@@ -2,6 +2,12 @@
 
     <logger name="com.core.api" level="TRACE"/>
 
+
+    <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>localhost:5044</destination>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>[%d{yyyy-MM-dd HH:mm:ss}] [%level] [%thread] %logger{36} - %msg%n</pattern>
@@ -25,6 +31,8 @@
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="FILE"/>
+        <appender-ref ref="LOGSTASH" />
+
     </root>
 
 </configuration>


### PR DESCRIPTION
### 문제점
- 기존 로그 설정에는 로그가 파일로만 저장되고 있었다.

### 해결 방법
- 로그를 Logstash로 직접 전송하도록 수정했다.
- Logstash에서 수집한 로그를 Elasticsearch에 저장하여 Kibana에서 실시간 확인 가능하게 설정하였다.
- 인덱스를 사용하여 날짜별로 로그 관리 할 수 있도록 설정하였다.

### 고민한 사항
1. Logstash가 다운되면 로그가 전송되지 않는다.
- Logstash 장애 시 failover.log에 저장 
- Logback 내부적으로 failover.log의 로그를 다시 Logstash로 전송 
-> 구현을 시도했으나 장애가 발생했을 때 이를 감지하고 자동으로 로그를 재전송하는 방법을 찾지 못했다.
-> 추후 해결 방안을 찾아서 추가할 계획이다.