### PR TITLE
GitHub API에서 자체 Git 서버 API로 변경 (브랜치 조회)

### DIFF
--- a/api/src/main/java/com/core/api/client/GitClient.java
+++ b/api/src/main/java/com/core/api/client/GitClient.java
@@ -1,0 +1,15 @@
+package com.core.api.client;
+
+import com.core.api.data.dto.response.BranchResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@FeignClient(name = "git", url = "http://localhost:8080")
+public interface GitClient {
+
+    @GetMapping("/branch/{owner}/{repo}")
+    List<BranchResponseDto> getBranches(@PathVariable("owner") String owner, @PathVariable("repo") String repo);
+}

--- a/api/src/main/java/com/core/api/service/BranchService.java
+++ b/api/src/main/java/com/core/api/service/BranchService.java
@@ -1,6 +1,7 @@
 package com.core.api.service;
 
 
+import com.core.api.client.GitClient;
 import com.core.api.client.GitHubClient;
 import com.core.api.data.dto.ChangeDto;
 import com.core.api.data.dto.FileDto;
@@ -23,16 +24,10 @@ public class BranchService {
 
     private final GitHubClient gitHubClient;
 
+    private final GitClient gitClient;
+
     public List<BranchResponseDto> getBranches(String owner, String repo) {
-        return gitHubClient.getBranches(owner, repo)
-                .stream()
-                .map(branch -> BranchResponseDto.from(
-                        (String) branch.get("name"),
-                        CommitServerDto.fromApiResponse(
-                                gitHubClient.getCommit(owner, repo, (String) ((Map<?, ?>) branch.get("commit")).get("sha"))
-                        )
-                ))
-                .toList();
+        return gitClient.getBranches(owner,repo);
     }
 
     public List<CompareBranchResponseDto> compareBranchHead(String owner, String repo, String baseHead) {


### PR DESCRIPTION
### 📌 변경 내용
- 기존 GitHubClient를 통해 GitHub API에서 브랜치 정보를 가져오던 로직을 제거
- 대신 GitClient를 통해 내부 구축한 자체 Git 서버 API로 브랜치 정보를 가져오도록 변경
- BranchService 내부의 getBranches 메서드 로직을 간소화하여 FeignClient로 직접 연동

### 💡 변경 이유
- 외부 의존성을 줄이고, 자체 Git 서버를 기반으로 일관된 데이터 제공을 위해 API 구조 전환